### PR TITLE
Remove <br/> tags from jussforskning-juridisk-kjønnsskifte

### DIFF
--- a/news_articles/jussforskning-juridisk-kjønnsskifte/jussforskning-juridisk-kjønnsskifte.html
+++ b/news_articles/jussforskning-juridisk-kjønnsskifte/jussforskning-juridisk-kjønnsskifte.html
@@ -118,7 +118,7 @@
       <blockquote>
         <p>– Før var man tvunget til å ha det kjønnet man ble tildelt ved fødselen i passet, uavhengig av hvordan man så ut i virkeligheten. En person med mannlig fødselskjønn ville altså vært oppført som mann i passet, men kunne se ut som en kvinne i passkontrollen. Loven endrer på dette slik at det blir lettere å sikre at oppgitt kjønn i passet samsvarer med personens faktiske utseende, sier han.</p>
       </blockquote>
-      <h3><br />Testikler og eggstokker</h3>
+      <h3>Testikler og eggstokker</h3>
       <p>Halvorsen nevner forøvrig to saker i Oslo tingrett der den gamle praksisen om juridisk kjønnsbytte var saksøkt, ved at det ble krevd erstatning for følgene av kravene. I første sak var spørsmålet om saksøker hadde krav på erstatning fordi hun ikke fikk endre juridisk kjønn uten å gjennomgå behandling og sterilisering.</p>
       <p>Retten kom til at staten hadde diskriminert på grunn av kjønnsidentitet, men at vilkårene for erstatning ikke var til stede.</p>
       <p>I sak nummer to var spørsmålet om et gjennomført steriliseringsinngrep i samband med endring av juridisk kjønn gav grunnlag for oppreisningserstatning. Likestillings- og diskrimineringsombudets mente ja, men retten mente nei, da sterilisering ikke var i strid med likestillingsloven.</p>
@@ -127,7 +127,7 @@
         <ul class="refList">
           <li class="ref">
             <div class="mixedCitation">
-              Likestillings- og diskrimineringsombudet liste over LHBT-saker:<br>
+              Likestillings- og diskrimineringsombudet liste over LHBT-saker:
               <a href="https://www.ldo.no/nyheiter-og-fag/klagesaker/lhbt/">https://www.ldo.no/nyheiter-og-fag/klagesaker/lhbt/</a>
             </div>
           </li>


### PR DESCRIPTION
Må fjerne `<br>`-taggene siden slate-editoren ikke lenger kommer til å støtte disse, da det bare fører til problemer.