### PR TITLE
Oppdaterer notis til kommentaren til straffeprosessloven

### DIFF
--- a/act_notices/lov-1981-05-22-25.json
+++ b/act_notices/lov-1981-05-22-25.json
@@ -1,4 +1,4 @@
 {
-  "heading": "Ajourføring av lovkommentaren til straffeprosessloven ventes våren 2019",
-  "body": "Etter utgivelse av lovkommentaren i papirformat i 2011 har verket kun blitt sporadisk oppdatert. Vi har derfor valgt å sette den opprinnelige publiseringsdatoen som bekreftet à jour-dato. Oppdatering av verket er forventet i løpet av våren 2019."
+  "heading": "Ajourføring av lovkommentaren til straffeprosessloven er under arbeid",
+  "body": "Etter utgivelse av lovkommentaren i papirformat i 2011 har verket kun blitt sporadisk oppdatert. Vi har derfor valgt å sette den opprinnelige publiseringsdatoen som bekreftet à jour-dato. Oppdatering av kommentarene fra første til fjerde del publiseres i løpet av juli 2019. Ny kommentar til hele loven vil foreligge våren 2020."
 }


### PR DESCRIPTION
Teksten var utdatert, da den refererte til at ajourføringer som enda ikke hadde kommet ville komme på et tidspunkt som allerede lå i fortiden.
Kom sammen med Rolf frem til ny tekst her.