### PR TITLE
Fjern lenke til statisk Shipbuilding Contracts i lista over ajourførte kommentarer

### DIFF
--- a/featured_commentaries.json
+++ b/featured_commentaries.json
@@ -6,12 +6,6 @@
     "category": ["fagbok", "juss", "kommentarutgave", "backlist"]
   },
   {
-    "id": "shipbuilding-contracts",
-    "type": "textbook",
-    "shortTitle": "Ship­building Contracts (kun PDF, ajourføres ikke)",
-    "category": ["fagbok", "juss", "kommentarutgave", "frontlist"]
-  },
-  {
     "id": "konkursloven",
     "type": "textbook",
     "shortTitle": "Konkurs­loven (kun PDF)",

--- a/legal_documents.json
+++ b/legal_documents.json
@@ -40,6 +40,16 @@
     }
   },
   {
+    "shortTitle": "Eierseksjonsloven 2017",
+    "exprId": {
+      "base": "NL",
+      "type": "lov",
+      "date": "2017-06-16",
+      "seq": 65,
+      "inForceAt": "2020-01-01"
+    }
+  },
+  {
     "shortTitle": "Straffegjennomføringsloven Kapittel 5",
     "exprId": {
       "base": "NL",

--- a/legal_documents.json
+++ b/legal_documents.json
@@ -68,5 +68,15 @@
       "seq": 679,
       "type": "lov"
     }
+  },
+  {
+    "shortTitle": "Shipbuilding Contracts",
+    "exprId": {
+      "base": "NL",
+      "type": "forskrift",
+      "date": "2000-01-01",
+      "seq": 1,
+      "inForceAt": "2000-01-01"
+    }
   }
 ]


### PR DESCRIPTION
Rolf publiserer ajourført versjon av Ship 2000 (Shipbuilding Contracts) nå.
Marie bad om eksplisitt årstall 2017 bak nye Eierseksjonsloven.