### PR TITLE
Spesifiserer at Arveloven-notisen skal vises i lovpanelet, og ikke i kommentarpanelet

### DIFF
--- a/act_notices/lov-2019-06-14-21.json
+++ b/act_notices/lov-2019-06-14-21.json
@@ -1,4 +1,5 @@
 {
+  "scope": "act",
   "heading": "Ikke i kraft",
   "body": "Loven trer i kraft 1. januar 2021."
 }


### PR DESCRIPTION
Innfører med dette en ny property `scope`, som er tiltenkt å enten ha verdi `"act`", eller ellers ha verdi `"commentary"` eller utelates (defaulter til kommentar).
Se https://github.com/universitetsforlaget/juridika-frontend/pull/847 for de nødvendige frontend-endringene.