### PR TITLE
Fjerner duplikate referanse-innslag i oppslaget fra referanser til verk

### DIFF
--- a/legal_references.tsv
+++ b/legal_references.tsv
@@ -13,7 +13,7 @@ almindelig borgerlig straffelov|alminnelig borgerlig straffelov|alminnelige stra
 animaliehygieneforskriften	forskrift/2008-12-22-1624
 animaliekontrollforskriften	forskrift/2008-12-22-1622
 arbeiderfondloven	lov/1938-04-08-2
-arbeidsledighetstrygdloven|arbeidsledighetstrygdloven	lov/1958-06-24-8
+arbeidsledighetstrygdloven	lov/1958-06-24-8
 arbeidstakeroppfinnelsesloven	lov/1970-04-17-21
 arbeidstidsloven	lov/1949-06-10-2|lov/1939-03-10-5
 arbeidstvisteloven|arbeidstvistloven	lov/2012-01-27-9|lov/1927-05-05-1
@@ -51,7 +51,6 @@ easa-forskriften	forskrift/2005-05-23-459
 eiendomsskatteloven|eigedomsskattelova|eigedomskattelova	lov/1975-06-06-29
 eksportkredittloven	lov/2012-06-22-57
 ekspropriasjonsloven	lov/1959-10-23-3|lov/1918-07-29-4|lov/1894-07-23-7
-ekspropriasjonserstatningsloven	lov/1984-04-06-17
 ektefellelovens ikrafttredelseslov|ektefællelovens ikrafttrædelseslov|ektefællelov ikrafttrædelseslov|ektefellelov ikrafttredelseslov|ektefællelovens ikrl|ektefællelov ikrl	lov/1927-05-20-2
 embedsedloven	lov/1981-05-22-23
 energiloven	lov/1990-06-29-50
@@ -325,7 +324,7 @@ forskrift til lov om kirkegårder, kremasjon og gravferd|gravferdsforskriften	fo
 forskrift til lov om straffegjennomføring|forskrift om straffegjennomføring|straffegjennomføringsforskriften	forskrift/2002-02-22-183
 forskrift til lov om toll og vareførsel|tolllovforskriften|tollforskriften	forskrift/2008-12-17-1502
 forskrift til lov om yrkesskadeforsikring|yrkesskadeforskriften	forskrift/1989-10-13-1041
-forskrift til merverdiavgiftsloven|merverdiavgiftsforskriften|fmval|fmva|fmva	forskrift/2009-12-15-1540
+forskrift til merverdiavgiftsloven|merverdiavgiftsforskriften|fmval|fmva	forskrift/2009-12-15-1540
 forskrift til offentleglova|offentlegforskrifta	forskrift/2008-10-17-1119
 forskrift til patentloven|patentforskriften	forskrift/2007-12-14-1417
 forskrift til privatskolelova	forskrift/2006-07-14-932
@@ -517,7 +516,7 @@ lov om enerett til firma og andre forretningskjennetegn|foretaksnavneloven|foret
 lov om enkje- og morstrygd	lov/1964-06-20-1
 lov om erstatning for rekvirerte skip	lov/1946-07-19-15
 lov om erstatning ved pasientskader mv|pasientskadeerstatningsloven|pasientskadeloven|passkl	lov/2001-06-15-53
-lov om erverv og utvinning av mineralressurser|mineralloven|mineralloven	lov/2009-06-19-101
+lov om erverv og utvinning av mineralressurser|mineralloven	lov/2009-06-19-101
 lov om etablering av leiligheter	lov/1976-05-28-36
 lov om etablering og gjennomføring av psykisk helsevern|lov om psykisk helsevern|psykisk helsevernloven|helsevernloven|phvl	lov/1999-07-02-62
 lov om etterretningstjenesten|etterretningsloven	lov/1998-03-20-11
@@ -548,7 +547,7 @@ lov om forbod mot samkvem med fienden	lov/1950-12-15-3
 lov om forbrukerkjøp|forbrukerkjøpsloven|forbrkjl	lov/2002-06-21-34
 lov om forbud mot at utlendinger driver fiske|fiskeriforbudsloven|fiskerigrenseloven	lov/1966-06-17-19
 lov om forbud mot diskriminering på grunn av etnisitet, religion|konvensjon om rasediskriminering|rasediskrimineringskonvensjon|rasediskrimineringsloven|diskrimineringsloven|dsketnl	lov/2005-06-03-33
-lov om forbud mot diskriminering på grunn av nedsatt funksjonsevne|diskriminerings- og tilgjengelighetsloven|funksjonsevnediskrimineringsloven|tilgjengelighetsloven|tilgjengelighetsloven	lov/2008-06-20-42
+lov om forbud mot diskriminering på grunn av nedsatt funksjonsevne|diskriminerings- og tilgjengelighetsloven|funksjonsevnediskrimineringsloven|tilgjengelighetsloven	lov/2008-06-20-42
 lov om forbud mot fallskjermhopping	lov/1987-06-12-57
 lov om forbud mot forsendelse av brændevin	lov/1917-05-25-1
 lov om forbud mot frakt av våpen mm	lov/1937-04-16
@@ -666,7 +665,7 @@ lov om konsesjon ved erverv av fast eiendom|konsesjonsloven	lov/2003-11-28-98
 lov om kontantstøtte|kontantstøtteloven	lov/1998-06-26-41
 lov om kontroll av post- og teletjenester	lov/1915-06-24-5
 lov om kontroll med eksport av strategiske varer, tjenester og teknologi m.v|eksportkontrolloven|våpeneksportloven	lov/1987-12-18-93
-lov om kontroll med etterretnings-, overvåkings-|lov om kontroll med hemmelige tjenester|eos-kontrolloven|eos-kontrolloven	lov/1995-02-03-7
+lov om kontroll med etterretnings-, overvåkings-|lov om kontroll med hemmelige tjenester|eos-kontrolloven	lov/1995-02-03-7
 lov om kontroll med markedsføring|markedsføringsloven|markedsføringloven|mfl	lov/2009-01-09-2
 lov om konvensjon norge/sverige om reinbeite	lov/1985-03-29-16
 lov om konvensjon om kjemiske våpen	lov/1994-05-06-10
@@ -688,7 +687,7 @@ lov om leilendingsgods tilhørende stamhus	lov/1888-06-23-3
 lov om likestillings- og diskrimineringsombudet|diskrimineringsombudsloven	lov/2005-06-10-40
 lov om lotterier mv|lotteriloven|lottl	lov/1995-02-24-11
 lov om lovvalg i forsikring|forsikringslovvalgslov|forsikringslovvalglov	lov/1992-11-27-111
-lov om luftfart|luftfartsloven|luftfartsloven	lov/1993-06-11-101
+lov om luftfart|luftfartsloven	lov/1993-06-11-101
 lov om lønnsnemnd i arbeidstvister	lov/2012-01-27-10
 lov om lønnsplikt under permittering|permitteringslønnsloven|permitteringsloven	lov/1988-05-06-22
 lov om løysingsrettar|løsningsrettsloven|løysingsrettslova|løsningsloven|løysingslova|løysl|løl	lov/1994-12-09-64
@@ -786,7 +785,7 @@ lov om overføring av domfelte|overføringsloven	lov/1991-07-20-67
 lov om overføring av rettigheter og forpliktelser ved omklassifisering	lov/2009-06-19-109
 lov om overtakelse av formuesposisjoner	lov/2003-09-12-94
 lov om pakkereiser|pakkereiseloven	lov/1995-08-25-57
-lov om pasient- og brukerrettigheter|pasient- og brukerrettighetsloven|lov om pasientrettigheter|pasientrettighetsloven|brukerrettighetsloven|brukerrettighetsloven|pasrl|pbrl	lov/1999-07-02-63
+lov om pasient- og brukerrettigheter|pasient- og brukerrettighetsloven|lov om pasientrettigheter|pasientrettighetsloven|brukerrettighetsloven|pasrl|pbrl	lov/1999-07-02-63
 lov om pass|passloven|passl	lov/1997-06-19-82
 lov om pengespill mv|pengespilloven	lov/1992-08-28-103
 lov om pensjon for ledsager i utenrikstjenesten	lov/1999-01-15-1
@@ -802,7 +801,7 @@ lov om personell i forsvaret|forsvarspersonelloven	lov/2004-07-02-59
 lov om personnavn|navneloven	lov/2002-06-07-19
 lov om personopplysninger|personopplysningsloven|pol	lov/2018-06-15-38|lov/2000-04-14-31
 lov om petroleumsvirksomhet|petroleumsvirksomhetsloven|petroleumsloven|petrl	lov/1996-11-29-72
-lov om planlegging og byggesaksbehandling|plan- og bygningsloven|bygningsloven|bygningsloven|plbl|pbl	lov/2008-06-27-71
+lov om planlegging og byggesaksbehandling|plan- og bygningsloven|bygningsloven|plbl|pbl	lov/2008-06-27-71
 lov om planteforedlerrett|planteforedlerrettsloven|planteforedlerrettloven|planteforedlerloven	lov/1993-03-12-32
 lov om pliktmessig avhold|avholdspliktloven	lov/1936-07-16-2
 lov om politiet|politiloven	lov/1995-08-04-53
@@ -829,7 +828,7 @@ lov om regulering av svine- og fjørfeproduksjon	lov/2004-01-16-5
 lov om regulerte markeder|børsloven	lov/2007-06-29-74
 lov om reinbeite mellom norge og sverige|reinbeiteloven	lov/1972-06-09-31
 lov om reindrift i visse kommuner	lov/1984-12-21-101
-lov om reindrift|reindriftsloven|reindriftsloven|reindriftsloven	lov/2007-06-15-40
+lov om reindrift|reindriftsloven	lov/2007-06-15-40
 lov om reingjerder mellom norge og finland	lov/1983-03-11-8
 lov om reisereservasjonssystemer	lov/2000-06-23-54
 lov om renter ved forsinket betaling|lov om rente ved forsinket betaling|lov om forsinket betaling|lov om forsinkelsesrente|forsinkelsesrenteloven|forseinkingsrentelova|forsinkelsesloven|morarenteloven|rl	lov/1976-12-17-100
@@ -867,12 +866,12 @@ lov om sosiale tjenester i arbeids- og velferdsforvaltningen	lov/2009-12-18-131
 lov om sosiale tjenester|lov om sosialtjenester|sosialtjenesteloven|sostjl|sostjel	lov/1991-12-13-81
 lov om spesialisthelsetjenesten|spesialisthelsetjenesteloven|speshtjl	lov/1999-07-02-61
 lov om stamhusene rosendal og jarlsberg	lov/1927-07-04-11
-lov om statens finansfond|finansfondsloven|finansfond-loven|finansfond-loven|finansfondloven	lov/2009-03-06-12
+lov om statens finansfond|finansfondsloven|finansfond-loven|finansfondloven	lov/2009-03-06-12
 lov om statens obligasjonsfond|obligasjonsfondsloven|obligasjonsfond-loven|obligasjonsfondloven	lov/2009-03-06-13
 lov om statens oppkrevere mv	lov/1958-03-28-4
 lov om statens pensjonsfond	lov/2005-12-21-123
 lov om statens premieobligasjonslån|premieobligasjonsloven	lov/1924-06-13-4
-lov om statens tjenestemenn|tjenestemannsloven|tjenestemannsloven|tjml	lov/1983-03-04-3
+lov om statens tjenestemenn|tjenestemannsloven|tjml	lov/1983-03-04-3
 lov om statens utleiebygg as	lov/2000-02-18-11
 lov om statleg varekrigsforsikring	lov/2003-12-12-115
 lov om statlig naturoppsyn|naturoppsynsloven	lov/1996-06-21-38
@@ -910,7 +909,7 @@ lov om tilvirkning av æthylæther	lov/1898-12-19-3
 lov om tinglysing|tinglysningsloven|tinglysingsloven|tgl	lov/1935-06-07-2
 lov om tjenestemannsretten	lov/1933-07-06-12
 lov om tjenesteplikt i politiet|polititjenesteloven	lov/1952-11-21-3
-lov om tjenestevirksomhet|lov om tjenestevirksomhet|tjenesteloven|tjenesteloven	lov/2009-06-19-103
+lov om tjenestevirksomhet|tjenesteloven	lov/2009-06-19-103
 lov om tjenesteytelser/sjøtransport	lov/1992-12-04-121
 lov om toll og vareførsel	lov/2007-12-21-119
 lov om tomtefeste|tomtefesteloven|festeloven	lov/1996-12-20-106
@@ -990,7 +989,7 @@ midl lov om regulering av byggevirksomhet	lov/1955-12-09-19
 midl lov om sivil tjenestepligkt for tannleger	lov/1956-06-21-11
 midl lov om uføretrygd	lov/1936-07-16-3
 midl strandplanlov|strandloven	lov/1965-06-25-5
-midlertidig lov om inntektsstopp|midlertidig lov om inntektsstopp	lov/1979-12-21-70
+midlertidig lov om inntektsstopp	lov/1979-12-21-70
 midlertidig lov om prøveordning med lokaler for injeksjon av narkotika	lov/2004-07-02-64
 midlertidig skattelov	lov/1952-06-13-8
 militære straffelov|militær straffelov|mil.strl|milstrl	lov/1902-05-22-13
@@ -1011,9 +1010,9 @@ opiumsloven	lov/1928-06-01-5
 opplæringsforskriften - opplæringslova|forskrift til opplæringslova	forskrift/2006-06-23-724
 opplæringslova|oppll|oppl	lov/1998-07-17-61
 oreigningsloven	lov/1959-10-23-3
-panteloven|panteloven|pantel	lov/1980-02-08-2
+panteloven|pantel	lov/1980-02-08-2
 passforskriften	forskrift/1999-12-09-1263
-patentloven|patentloven|pl	lov/1967-12-15-9
+patentloven|pl	lov/1967-12-15-9
 patentstyrelova	lov/2012-06-22-58
 pensjonslov for stortingsrepresentanter	lov/1981-06-12-61
 personopplysningsforskriften|pof	forskrift/2000-12-15-1265
@@ -1154,14 +1153,14 @@ vassdragslov i ht konv norge/ sverige	lov/1931-06-12-1
 vassdragsloven|vasdragsloven	lov/1887-07-01-4
 vassdragsreguleringsloven	lov/1917-12-14-17|lov/1911-08-04
 vedlegg til konvensjon om intern løsørek	lov/1988-05-13-426
-vegfraktavtaleloven|veifraktavtaleloven|vegfraktavtaleloven|veifraktavtaleloven|veifraktloven|vegfraktloven|veifraktloven|vegfraktloven|veifraktl|veifraktl	lov/1974-12-20-68
+vegfraktavtaleloven|veifraktavtaleloven|veifraktloven|vegfraktloven|veifraktl	lov/1974-12-20-68
 vegloven|veiloven	lov/1963-06-21-23|lov/1912-06-21-1
 vegtrafikkloven|veitrafikkloven|vegtrl|vtrl	lov/1965-06-18-4
 vekselloven	lov/1932-05-27-2
 verdipapirfondloven	lov/2011-11-25-44|lov/1981-06-12-52
 verdipapirloven	lov/1981-06-12-52
 vergemaalsloven	lov/1927-04-22-3
-vergemålsloven|vergemålsloven|vgml	lov/2010-03-26-9
+vergemålsloven	lov/2010-03-26-9
 vernepliktsloven	lov/1953-07-17-29|lov/1929-06-21-8
 vexelloven	lov/1880-05-07
 vexelprocessloven	lov/1880-06-17


### PR DESCRIPTION
Yngve påpekte at det var noen "dubletter" i lista jeg sendte ham over alle lovnavnene (altså denne lista her, transformert til et annet format via https://github.com/universitetsforlaget/scripts/pull/336).

Det er jo ikke ønskelig med duplikater i denne lista, så her har jeg fjerna alle. Fant bare duplikater der samme referanse pekte flere ganger til samme verk (i de fleste tilfeller på samme rad i denne lista), fant ingen duplikater der samme referanse pekte til forskjellige verk.

Teknisk detalj: Jeg fant duplikatene ved å kjøre kommandoen `$ uniq -d output/lovnavn.tsv` på resultatet av https://github.com/universitetsforlaget/scripts/pull/336 skriptet.