### PR TITLE
Fjerner notis om at Arveloven 2019 ikke enda har trådt i kraft, siden den nå har det

### DIFF
--- a/act_notices/lov-2019-06-14-21.json
+++ b/act_notices/lov-2019-06-14-21.json
@@ -1,5 +1,0 @@
-{
-  "scope": "act",
-  "heading": "Ikke i kraft",
-  "body": "Loven trer i kraft 1. januar 2021."
-}


### PR DESCRIPTION
Reverserer https://github.com/universitetsforlaget/static_content/pull/274.
Se også https://github.com/universitetsforlaget/static_content/pull/276.