### PR TITLE
Legger til act notice for Barnelova

### DIFF
--- a/act_notices/lov-1981-04-08-7.json
+++ b/act_notices/lov-1981-04-08-7.json
@@ -1,3 +1,4 @@
 {
-  "heading": "Lovkommentaren til barnelova ajourføres ikke"
+  "heading": "Lovkommentaren til barnelova ajourføres ikke",
+  "body": null
 }

--- a/act_notices/lov-1981-04-08-7.json
+++ b/act_notices/lov-1981-04-08-7.json
@@ -1,0 +1,3 @@
+{
+  "heading": "Lovkommentaren til barnelova ajourføres ikke"
+}


### PR DESCRIPTION
Rolf forespurte dette [på slack](https://universitetsforlaget.slack.com/archives/CG2PYFCCX/p1629793175000500?thread_ts=1629450435.013200&cid=CG2PYFCCX):
>rolf  5 hours ago
Husker ikke helt hvorfor det ble valgt ulike løsninger for barnelov og utlendingslov, men det ble gått en del runder på det den gangen. Jeg mener nok også at en lignende notis på paragrafnivå i barnelova som utlendingsloven har, vil være en bedre løsning enn det vi har nå.
>
>Anders T  5 hours ago
Jeg kan godt innføre varsel om at kommentaren ikke ajourføres også for barnelova rolf, det er ikke noe stress. Skal jeg gjøre det?
>
>rolf  4 hours ago
Ja takk! Tror kanskje vi kan begrense teksten i notisen til "Lovkommentaren til barnelova ajourføres ikke", uten videre utbrodering. Ny utgave er ikke planlagt før i 2024, dessuten er det mye som kan tyde på at en helt ny lov kan være i kjømda, kommer kanskje til og med tidligere enn 2024.

Tolket "uten videre utbrodering" som at vi bare skulle ha overskrift (`heading`) og ikke noe undertekst (`body`).

Avhenger av https://github.com/universitetsforlaget/graphql-gateway/pull/251 og https://github.com/universitetsforlaget/juridika-frontend/pull/1161