### PR TITLE
remove notice on now up to date commentary

### DIFF
--- a/act_notices/lov-2008-05-15-35.json
+++ b/act_notices/lov-2008-05-15-35.json
@@ -1,4 +1,0 @@
-{
-  "heading": "Lovkommentaren til utlendingsloven ajourføres ikke",
-  "body": "Etter utgivelse av lovkommentaren i papirformat i 2010 har verket kun blitt sporadisk oppdatert."
-}


### PR DESCRIPTION
Fjerner filen som beskriver en notis. Dette repoet sjekkes av graphql når man gjør en spørring om en lovkommentar